### PR TITLE
Database name is ignored in tablenames

### DIFF
--- a/src/main/java/org/xbib/jdbc/csv/CsvDatabaseMetaData.java
+++ b/src/main/java/org/xbib/jdbc/csv/CsvDatabaseMetaData.java
@@ -16,7 +16,7 @@ import java.util.List;
  * CsvJdbc driver.
  */
 public class CsvDatabaseMetaData implements DatabaseMetaData {
-    private static final String SCHEMA_NAME = "PUBLIC";
+    public static final String SCHEMA_NAME = "PUBLIC";
 
     private Connection createdByConnection;
     private CsvStatement internalStatement = null;

--- a/src/main/java/org/xbib/jdbc/csv/ParsedTable.java
+++ b/src/main/java/org/xbib/jdbc/csv/ParsedTable.java
@@ -12,7 +12,7 @@ class ParsedTable {
     public ParsedTable(String tableName, String tableAlias) {
         this.joinType = JoinType.NONE;
         this.joinClause = null;
-        this.tableName = tableName;
+        this.tableName = tableName.replace(CsvDatabaseMetaData.SCHEMA_NAME + ".", "");
         this.tableAlias = tableAlias;
     }
 
@@ -20,7 +20,7 @@ class ParsedTable {
                        String tableName, String tableAlias) {
         this.joinType = joinType;
         this.joinClause = joinClause;
-        this.tableName = tableName;
+        this.tableName = tableName.replace(CsvDatabaseMetaData.SCHEMA_NAME + ".", "");
         this.tableAlias = tableAlias;
     }
 


### PR DESCRIPTION
When ParsedTable sets the tableName from the parsed SQL, the database name is removed from the table name. So PUBLIC.myTable becomes myTable.
If this is not done, the software will try to open the file PUBLIC.myTable.csv, which do not exist.